### PR TITLE
Rebalancing and how-to pages

### DIFF
--- a/asf_levies_model_app/pages/1_❓_How-to.py
+++ b/asf_levies_model_app/pages/1_❓_How-to.py
@@ -12,8 +12,9 @@ st.markdown(
 
 st.subheader("What is this tool?")
 st.markdown(
-    "This tool allows you to **test different levy reform scenarios** and shows you the effect on "
-    "(i) the **relative cost of electricity to gas** and (ii) **changes in energy bills** of different types of households in Great Britain."
+    """
+            This tool allows you to **test different levy reform scenarios** and shows you the effect on (i) the **relative cost of electricity to gas** and (ii) **changes in energy bills** of different types of households in Great Britain.
+"""
 )
 st.markdown(
     "This tool is powered by our analytical [**Python model**](https://github.com/nestauk/asf_levies_model),"
@@ -24,52 +25,54 @@ st.markdown(
     "*Read more about how we developed the model and app.* (to add link to Medium blog)"
 )
 
+st.markdown("---")
 
 st.subheader("How do I use this tool?")
+
 st.markdown(
     """
-On the **🎯Run a rebalancing scenario** page, you can test a levy reform scenario by adjusting the settings in the **sidebar**.
+On the **🎯 Run a rebalancing scenario** page, you can test a levy reform scenario by adjusting the settings in the **sidebar**.
+(Learn more about the [schemes](https://www.ofgem.gov.uk/environmental-and-social-schemes) that each levy funds.)
+
+#### **Option A. Choose a preset approach**
+   The default setting is the current situation, but you can choose from different preset approaches.
+
+#### **Option B. Create your own approach**
+   Manually adjust the configuration for each levy. The settings will initially be set to the current situation.
+
+For each levy, you can choose to:
+- **Continue levying on electricity and/or gas bills**, or
+- **Remove the levy from bills** and fund it through public spending.
+
+If continuing to levy on bills:
+- Choose what **percentage** of the levy amount to raise from **electricity vs. gas** bills.
+- Choose the levy type: **Unit cost** (£/MWh) or **Standing charge** (£/customer).
+
+##### As you make changes, you'll see:
+- The **electricity to gas unit cost ratio**
+  (Learn more: [Electricity to gas price ratio](https://www.nesta.org.uk/blog/the-electricity-to-gas-price-ratio-explained-how-a-green-ratio-would-make-bills-cheaper-and-greener/)).
+
+- The **total cost** removed off bills **to be funded by general taxation**
+
+- The **typical household bill**, using the [medium energy use](https://www.ofgem.gov.uk/information-consumers/energy-advice-households/average-gas-and-electricity-use-explained) values used for Ofgem's energy price cap
+
+- The **change to energy bills** for different **UK energy consumer archetypes**
+  (Learn more: [Ofgem archetypes](https://www.ofgem.gov.uk/energy-policy-and-regulation/measuring-impact-our-policy-decisions)).
+
+##### Additional Features:
+- **View and download** the **underlying results data** table for bill changes across archetypes.
 """
 )
-st.markdown(
-    """ To test a levy reform scenario, you can do one of:
 
-- **Choose a preset approach.**<br>
-   *When you first open the page, it defaults to the current situation.*
-
-
-- **Create your own approach by manually adjusting the configuration for each levy.**<br>
-   *When you first select this option, all the settings are set to the current situation.*<br><br>
-   **For each levy**, you can choose:
-   - Continue to **levy on electricity and/or gas bills**, or remove off energy bills entirely and **fund through public spending**.
-   - If levying on bills, you can then choose what **percentage** of the scheme amount **to raise from electricity vs. gas** bills.
-   - You can also choose to **change** the levy from a **unit cost** (£/MWh) or **standing charge** (£/customer).
-""",
-    unsafe_allow_html=True,
-)
-st.markdown(
-    """
-    As you change the settings, you will see their effects on the [**electricity to gas unit cost ratio**](https://www.nesta.org.uk/blog/the-electricity-to-gas-price-ratio-explained-how-a-green-ratio-would-make-bills-cheaper-and-greener/)
-    and the energy bills of different [**UK energy consumer archetypes**](https://www.ofgem.gov.uk/energy-policy-and-regulation/measuring-impact-our-policy-decisions).
-"""
-)
-st.markdown(
-    "You also have the option to **view, and download**, the **underlying results data** table for the bill changes across archetypes."
-)
-
+st.markdown("---")
 
 st.subheader("Why did we build this tool?")
 st.markdown(
     """
-At Nesta, we're on a mission to **decarbonise home heating**. Residential buildings are a major source of UK carbon emissions because of their reliance on fossil fuels for heat.
-Our team in A Sustainable Future focuses on facilitating adoption of **low-carbon heating systems to cut these emissions**.<br>
+At Nesta, our mission is to **decarbonise home heating**. Residential buildings are a major source of UK carbon emissions due to their reliance on fossil fuels for heat. In the A Sustainable Future team, we're working to facilitate the adoption of **low-carbon heating systems** to reduce these emissions.
 
-With **electricity costing nearly four times more than gas** (as of March 2025), switching from gas boilers to low-carbon technologies such as electric heat pumps is not financially appealing for many households.
-One way to **make electricity more affordable** is to **adjust the levies** that are added to energy bills which fund environmental and social policy schemes.
-Currently, most of these levies are added to electricity bills.<br>
+With **electricity nearly four times more expensive than gas** (as of March 2025), switching from gas boilers to electric heat pumps is financially challenging for many households. One way to **make electricity more affordable** is to **adjust the levies** that fund environmental and social policy schemes. Currently, most of these levies are added to electricity bills.
 
-We believe that **shifting levies from electricity to gas** is essential to enabling a **nationwide heating transition** away from gas and for **sustainably
-lowering energy bills**.<br>
-""",
-    unsafe_allow_html=True,
+We believe that **shifting levies from electricity to gas** is key to enabling a nationwide **transition to low-carbon heating** while **sustainably lowering energy bills**.
+"""
 )

--- a/asf_levies_model_app/pages/1_❓_How-to.py
+++ b/asf_levies_model_app/pages/1_❓_How-to.py
@@ -1,0 +1,75 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="Nesta Levies Rebalancing Model", page_icon="🏠", layout="wide"
+)
+
+st.title("Levies Rebalancing App💡")
+st.markdown(
+    "**from the [A Sustainable Future](https://www.nesta.org.uk/sustainable-future/) team at Nesta**"
+)
+
+
+st.subheader("What is this tool?")
+st.markdown(
+    "This tool allows you to **test different levy reform scenarios** and shows you the effect on "
+    "(i) the **relative cost of electricity to gas** and (ii) **changes in energy bills** of different types of households in Great Britain."
+)
+st.markdown(
+    "This tool is powered by our analytical [**Python model**](https://github.com/nestauk/asf_levies_model),"
+    " developed as part of our project on [**making energy cheaper by rebalancing levies**]"
+    "(https://www.nesta.org.uk/project/finding-ways-to-deliver-cheaper-electricity-by-rebalancing-levies/)."
+)
+st.markdown(
+    "*Read more about how we developed the model and app.* (to add link to Medium blog)"
+)
+
+
+st.subheader("How do I use this tool?")
+st.markdown(
+    """
+On the **🎯Run a rebalancing scenario** page, you can test a levy reform scenario by adjusting the settings in the **sidebar**.
+"""
+)
+st.markdown(
+    """ To test a levy reform scenario, you can do one of:
+
+- **Choose a preset approach.**<br>
+   *When you first open the page, it defaults to the current situation.*
+
+
+- **Create your own approach by manually adjusting the configuration for each levy.**<br>
+   *When you first select this option, all the settings are set to the current situation.*<br><br>
+   **For each levy**, you can choose:
+   - Continue to **levy on electricity and/or gas bills**, or remove off energy bills entirely and **fund through public spending**.
+   - If levying on bills, you can then choose what **percentage** of the scheme amount **to raise from electricity vs. gas** bills.
+   - You can also choose to **change** the levy from a **unit cost** (£/MWh) or **standing charge** (£/customer).
+""",
+    unsafe_allow_html=True,
+)
+st.markdown(
+    """
+    As you change the settings, you will see their effects on the [**electricity to gas unit cost ratio**](https://www.nesta.org.uk/blog/the-electricity-to-gas-price-ratio-explained-how-a-green-ratio-would-make-bills-cheaper-and-greener/)
+    and the energy bills of different [**UK energy consumer archetypes**](https://www.ofgem.gov.uk/energy-policy-and-regulation/measuring-impact-our-policy-decisions).
+"""
+)
+st.markdown(
+    "You also have the option to **view, and download**, the **underlying results data** table for the bill changes across archetypes."
+)
+
+
+st.subheader("Why did we build this tool?")
+st.markdown(
+    """
+At Nesta, we're on a mission to **decarbonise home heating**. Residential buildings are a major source of UK carbon emissions because of their reliance on fossil fuels for heat.
+Our team in A Sustainable Future focuses on facilitating adoption of **low-carbon heating systems to cut these emissions**.<br>
+
+With **electricity costing nearly four times more than gas** (as of March 2025), switching from gas boilers to low-carbon technologies such as electric heat pumps is not financially appealing for many households.
+One way to **make electricity more affordable** is to **adjust the levies** that are added to energy bills which fund environmental and social policy schemes.
+Currently, most of these levies are added to electricity bills.<br>
+
+We believe that **shifting levies from electricity to gas** is essential to enabling a **nationwide heating transition** away from gas and for **sustainably
+lowering energy bills**.<br>
+""",
+    unsafe_allow_html=True,
+)

--- a/asf_levies_model_app/utils/app_utils.py
+++ b/asf_levies_model_app/utils/app_utils.py
@@ -1,0 +1,450 @@
+import streamlit as st
+import pandas as pd
+import altair as alt
+
+from typing import List, Dict
+
+import asf_levies_model.getters.load_data as data
+
+import asf_levies_model.levies as levies
+import asf_levies_model.tariffs as tariffs
+
+from asf_levies_model.levies import Levy, LevyCollection
+
+from asf_levies_model.tariffs import ElectricityOtherPayment, GasOtherPayment
+
+from asf_levies_model.consumers import Consumer, ConsumerCollection
+
+from asf_levies_model.summary import create_scenario_weights_dict
+
+
+def instantiate_levies(
+    supply_elec: float = 96_517_461.0,  # MWh
+    supply_gas: float = 266_505_188.0,  # MWh
+    customers_elec: int = 29_239_936,
+    customers_gas: int = 24_605_467,
+) -> LevyCollection:
+
+    denominator_values = {
+        "supply_elec": supply_elec,
+        "supply_gas": supply_gas,
+        "customers_gas": customers_gas,
+        "customers_elec": customers_elec,
+    }
+
+    # Scaling factor for estimating domestic share of FIT revenue
+    total_supply_elec = (
+        249_044_438  # DESNZ GB total electricity consumption - all meters (2023)
+    )
+    exempt_eii_supply = (
+        10_529_633  # Apr-Jun2025 period, Annex 4, New FIT methodology tab
+    )
+    fit_scaling_factor = supply_elec / (total_supply_elec - exempt_eii_supply)
+
+    # Scaling factor for estimating domestic share of NCC revenue
+    ncc_eligible_supply = (
+        119_380_310.7  # Mar-Jun2025 period, Annex 4, NCC methodology tab
+    )
+    ncc_scaling_factor = supply_elec / ncc_eligible_supply
+
+    # Instantiate status quo levies with Annex 4 data
+    @st.cache_data
+    def load_annex_4():
+        return data.download_annex_4(as_fileobject=True)
+
+    fileobject = load_annex_4()
+    list_levies = [
+        levies.RO.from_dataframe(
+            data.process_data_RO(fileobject), denominator=supply_elec
+        ),
+        levies.AAHEDC.from_dataframe(
+            data.process_data_AAHEDC(fileobject), denominator=supply_elec
+        ),
+        levies.GGL.from_dataframe(
+            data.process_data_GGL(fileobject), denominator=customers_gas
+        ),
+        levies.WHD.from_dataframe(
+            data.process_data_WHD(fileobject),
+            customers_gas=customers_gas,
+            customers_elec=customers_elec,
+        ),
+        levies.ECO.from_dataframe(data.process_data_ECO(fileobject)),
+        levies.FIT.from_dataframe(
+            data.process_data_FIT(fileobject),
+            scaling_factor=fit_scaling_factor,
+        ),
+        levies.NCC.from_dataframe(
+            data.process_data_NCC(fileobject), scaling_factor=ncc_scaling_factor
+        ),
+    ]
+    fileobject.close()
+    pc = levies.LevyCollection("Policy Costs", "pc", list_levies, denominator_values)
+
+    # Rebalance baseline levies to reflect denominators
+    pc = pc.rebalance_to_denominators()
+
+    return pc
+
+
+def get_approach_weights(levies: List, approach_name: str) -> Dict:
+
+    # "Current"
+    baseline_weights = create_scenario_weights_dict(levies)
+
+    # "Rebalance all levies on electricity to gas"
+    all_gas_weights = create_scenario_weights_dict(levies)
+    for levy in [levy for levy in levies if levy.electricity_weight > 0]:
+        all_gas_weights[levy.short_name] = {
+            "new_electricity_weight": 0.0,
+            "new_gas_weight": 1.0,
+            "new_tax_weight": 0.0,
+            "new_variable_weight_elec": 0.0,
+            "new_fixed_weight_elec": 0.0,
+            "new_variable_weight_gas": levy.electricity_variable_weight,
+            "new_fixed_weight_gas": levy.electricity_fixed_weight,
+        }
+
+    # "Rebalance RO and FIT levies from electricity to gas"
+    rebalance_ro_fit_weights = create_scenario_weights_dict(levies)
+    for levy in [levy for levy in levies if levy.short_name in ["ro", "fit"]]:
+        rebalance_ro_fit_weights[levy.short_name] = {
+            "new_electricity_weight": 0.0,
+            "new_gas_weight": 1.0,
+            "new_tax_weight": 0.0,
+            "new_variable_weight_elec": 0.0,
+            "new_fixed_weight_elec": 0.0,
+            "new_variable_weight_gas": levy.electricity_variable_weight,
+            "new_fixed_weight_gas": levy.electricity_fixed_weight,
+        }
+
+    # "Remove all levies on electricity to taxation"
+    sq_electricity_removal_weights = create_scenario_weights_dict(levies)
+    for levy in [levy.short_name for levy in levies if levy.electricity_weight > 0]:
+        sq_electricity_removal_weights[levy]["new_tax_weight"] = (
+            sq_electricity_removal_weights[levy]["new_electricity_weight"]
+        )
+
+        for weight_type in [
+            "new_electricity_weight",
+            "new_variable_weight_elec",
+            "new_fixed_weight_elec",
+        ]:
+            sq_electricity_removal_weights[levy][weight_type] = 0.0
+
+    # "Remove RO and FIT levies from electricity to taxation"
+    remove_ro_fit_weights = create_scenario_weights_dict(levies)
+    for levy in ["ro", "fit"]:
+        remove_ro_fit_weights[levy]["new_tax_weight"] = remove_ro_fit_weights[levy][
+            "new_electricity_weight"
+        ]
+
+        for weight_type in [
+            "new_electricity_weight",
+            "new_variable_weight_elec",
+            "new_fixed_weight_elec",
+        ]:
+            remove_ro_fit_weights[levy][weight_type] = 0.0
+
+    # Create lookup dictionary for weights of each approach
+    approach_weights = {
+        "Current": baseline_weights,
+        "Rebalance all levies on electricity to gas": all_gas_weights,
+        "Rebalance RO and FIT levies from electricity to gas": rebalance_ro_fit_weights,
+        "Remove all levies on electricity to taxation": sq_electricity_removal_weights,
+        "Remove RO and FIT levies from electricity to taxation": remove_ro_fit_weights,
+    }
+
+    if approach_name not in approach_weights.keys():
+        raise ValueError("Rebalancing approach name not recognised.")
+
+    return approach_weights[approach_name]
+
+
+def instantiate_tariffs(payment_method: str = "Other Payment") -> Dict:
+
+    # Load Annex 9
+    @st.cache_data
+    def load_annex_9():
+        return data.download_annex_9(as_fileobject=True)
+
+    fileobject_annex_9 = load_annex_9()
+
+    # Load tariff tables from Annex 9
+    # Other payment
+    elec_other_payment_nil = data.process_tariff_elec_other_payment_nil(
+        fileobject_annex_9
+    )
+    elec_other_payment_typical = data.process_tariff_elec_other_payment_typical(
+        fileobject_annex_9
+    )
+    gas_other_payment_nil = data.process_tariff_gas_other_payment_nil(
+        fileobject_annex_9
+    )
+    gas_other_payment_typical = data.process_tariff_gas_other_payment_typical(
+        fileobject_annex_9
+    )
+    # Prepayment meter
+    elec_ppm_nil = data.process_tariff_elec_ppm_nil(fileobject_annex_9)
+    elec_ppm_typical = data.process_tariff_elec_ppm_typical(fileobject_annex_9)
+    gas_ppm_nil = data.process_tariff_gas_ppm_nil(fileobject_annex_9)
+    gas_ppm_typical = data.process_tariff_gas_ppm_typical(fileobject_annex_9)
+    # Standard Credit
+    elec_standard_credit_nil = data.process_tariff_elec_standard_credit_nil(
+        fileobject_annex_9
+    )
+    elec_standard_credit_typical = data.process_tariff_elec_standard_credit_typical(
+        fileobject_annex_9
+    )
+    gas_standard_credit_nil = data.process_tariff_gas_standard_credit_nil(
+        fileobject_annex_9
+    )
+    gas_standard_credit_typical = data.process_tariff_gas_standard_credit_typical(
+        fileobject_annex_9
+    )
+    fileobject_annex_9.close()
+
+    # Instantiate Tariff objects
+    if payment_method == "Other Payment":
+        electricity_tariff = ElectricityOtherPayment.from_dataframe(
+            elec_other_payment_nil, elec_other_payment_typical
+        )
+        gas_tariff = GasOtherPayment.from_dataframe(
+            gas_other_payment_nil, gas_other_payment_typical
+        )
+    elif payment_method == "PPM":
+        electricity_tariff = ElectricityOtherPayment.from_dataframe(
+            elec_ppm_nil, elec_ppm_typical
+        )
+        gas_tariff = GasOtherPayment.from_dataframe(gas_ppm_nil, gas_ppm_typical)
+    elif payment_method == "Standard Credit":
+        electricity_tariff = ElectricityOtherPayment.from_dataframe(
+            elec_standard_credit_nil, elec_standard_credit_typical
+        )
+        gas_tariff = GasOtherPayment.from_dataframe(
+            gas_standard_credit_nil, gas_standard_credit_typical
+        )
+    else:
+        raise ValueError("Payment method not recognised.")
+
+    return {"electricity": electricity_tariff, "gas": gas_tariff}
+
+
+def update_electricity_tariff_policy_cost(tariff, levies):
+    tariff.pc_nil = sum([levy.calculate_levy(0, 0, True, False) for levy in levies])
+    tariff.pc = sum([levy.calculate_levy(1, 0, False, False) for levy in levies])
+    return tariff
+
+
+def update_gas_tariff_policy_cost(tariff, levies):
+    tariff.pc_nil = sum([levy.calculate_levy(0, 0, False, True) for levy in levies])
+    tariff.pc = sum([levy.calculate_levy(0, 1, False, False) for levy in levies])
+    return tariff
+
+
+def instantiate_archetype_consumers(gas_tariff, electricity_tariff):
+
+    # Load Ofgem energy consumer archetypes data
+    @st.cache_data
+    def load_archetypes():
+        return data.ofgem_archetypes_data()
+
+    ofgem_archetypes_df = load_archetypes()
+
+    # Create list of Consumers (Average Ofgem archetypes only, n=24)
+    consumers = [
+        Consumer.consumer_from_dataframe(
+            df=ofgem_archetypes_df,
+            row=row,
+            name_col="AnnualConsumptionProfile",
+            archetype_col="AnnualConsumptionProfile",
+            net_annual_income_col="NetAnnualHouseholdIncome",
+            main_heating_fuel_col="ArchetypeHeatingFuel",
+            gas_consumption_col="GaskWh",
+            electricity_consumption_col="ElectricitySingleRatekWh",
+            gas_tariff=gas_tariff,
+            electricity_tariff=electricity_tariff,
+            unit_converter=1_000,
+        )
+        for row in range(1, 25)
+    ]
+
+    return consumers
+
+
+def instantiate_archetype_consumers_with_eligibility(
+    gas_tariff, electricity_tariff, eligibility_size_name
+):
+
+    # Load Ofgem energy consumer archetypes data
+    @st.cache_data
+    def load_archetypes():
+        return data.ofgem_archetypes_data()
+
+    ofgem_archetypes_df = load_archetypes()
+
+    # Create list of eligible Consumers (Average Ofgem archetypes only, n=24)
+    eligible_consumers = [
+        Consumer(
+            name=ofgem_archetypes_df.loc[row, "AnnualConsumptionProfile"],
+            archetype=ofgem_archetypes_df.loc[row, "AnnualConsumptionProfile"],
+            net_annual_income=ofgem_archetypes_df.loc[row, "NetAnnualHouseholdIncome"],
+            net_income_decile=ofgem_archetypes_df.loc[row, "NetIncomeDecile"],
+            main_heating_fuel=ofgem_archetypes_df.loc[row, "ArchetypeHeatingFuel"],
+            gas_consumption=ofgem_archetypes_df.loc[row, "GaskWh"] / 1_000,
+            electricity_consumption=ofgem_archetypes_df.loc[
+                row, "ElectricitySingleRatekWh"
+            ]
+            / 1_000,
+            gas_tariff=gas_tariff,
+            electricity_tariff=electricity_tariff,
+            # size=ofgem_archetypes_df.loc[row, eligibility_size_name],
+            scheme_eligible=True,
+        )
+        for row in range(1, 25)
+    ]
+
+    # Create list of ineligible Consumers (Average Ofgem archetypes only, n=24)
+    ineligible_consumers = [
+        Consumer(
+            name=ofgem_archetypes_df.loc[row, "AnnualConsumptionProfile"],
+            archetype=ofgem_archetypes_df.loc[row, "AnnualConsumptionProfile"],
+            net_annual_income=ofgem_archetypes_df.loc[row, "NetAnnualHouseholdIncome"],
+            net_income_decile=ofgem_archetypes_df.loc[row, "NetIncomeDecile"],
+            main_heating_fuel=ofgem_archetypes_df.loc[row, "ArchetypeHeatingFuel"],
+            gas_consumption=ofgem_archetypes_df.loc[row, "GaskWh"] / 1_000,
+            electricity_consumption=ofgem_archetypes_df.loc[
+                row, "ElectricitySingleRatekWh"
+            ]
+            / 1_000,
+            gas_tariff=gas_tariff,
+            electricity_tariff=electricity_tariff,
+            # size=ofgem_archetypes_df.loc[row, "ArchetypeSize"]
+            # - ofgem_archetypes_df.loc[row, eligibility_size_name],
+            scheme_eligible=True,
+        )
+        for row in range(1, 25)
+    ]
+    return eligible_consumers, ineligible_consumers
+
+
+def calculate_unit_cost_ratio(electricity_tariff, gas_tariff):
+    return electricity_tariff.calculate_variable_consumption(
+        1
+    ) / gas_tariff.calculate_variable_consumption(1)
+
+
+def instantiate_new_levy(
+    new_levy_name,
+    new_levy_revenue,
+    new_levy_fuel,
+    new_levy_type,
+    supply_elec,
+    customers_elec,
+    supply_gas,
+    customers_gas,
+):
+
+    electricity_fixed_weight = (
+        1
+        if (new_levy_fuel == "Electricity") & (new_levy_type == "Standing charge")
+        else 0
+    )
+    electricity_variable_weight = (
+        1 if (new_levy_fuel == "Electricity") & (new_levy_type == "Consumption") else 0
+    )
+    gas_variable_weight = (
+        1 if (new_levy_fuel == "Gas") & (new_levy_type == "Consumption") else 0
+    )
+    gas_fixed_weight = (
+        1 if (new_levy_fuel == "Gas") & (new_levy_type == "Standing charge") else 0
+    )
+
+    new_levy = Levy(
+        name=new_levy_name,
+        short_name=new_levy_name,
+        electricity_weight=1 if new_levy_fuel == "Electricity" else 0,
+        gas_weight=1 if new_levy_fuel == "Gas" else 0,
+        tax_weight=0,
+        electricity_variable_weight=electricity_variable_weight,
+        electricity_fixed_weight=electricity_fixed_weight,
+        gas_variable_weight=gas_variable_weight,
+        gas_fixed_weight=gas_fixed_weight,
+        electricity_variable_rate=(new_levy_revenue / supply_elec)
+        * electricity_variable_weight,
+        electricity_fixed_rate=(new_levy_revenue / customers_elec)
+        * electricity_fixed_weight,
+        gas_variable_rate=(new_levy_revenue / supply_gas) * gas_variable_weight,
+        gas_fixed_rate=(new_levy_revenue / customers_gas) * gas_fixed_weight,
+        general_taxation=0,
+        revenue=new_levy_revenue,
+        price_cap_period="LATEST",
+    )
+
+    return new_levy
+
+
+def get_tidy_summary(consumers, scenario_name):
+    tidy_summary = pd.concat([consumer.get_tidy_summary() for consumer in consumers])
+    tidy_summary["Scenario"] = scenario_name
+    return tidy_summary
+
+
+def tidy_to_pivot_summary(tidy_summary):
+    pivot_summary_table = tidy_summary.pivot_table(
+        index=["Name", "Scenario"], columns="Attribute", values="Value", aggfunc="first"
+    ).reset_index()
+    pivot_summary_table = pivot_summary_table[
+        [
+            "Name",
+            "Scenario",
+            "main_heating_fuel",
+            "electricity_bill",
+            "gas_bill",
+            "combined_fuel_bill",
+            "fuel_poverty_gap",
+        ]
+    ].sort_values(by=["Scenario", "Name"])
+    return pivot_summary_table
+
+
+def make_archetype_bill_change_chart(rebalanced_summary_table, chart_width=1000):
+
+    # Fuel colours
+    cmap_2 = {
+        "Electricity": "#15A38C",
+        "Electricity/Other": "#d8d2ca",
+        "Gas": "#0000ff",
+        "Other": "#F6B0C0",
+    }
+
+    chart = alt.Chart(rebalanced_summary_table)
+    # Dots
+    points = chart.mark_point(opacity=1, filled=True).encode(
+        x=alt.X(
+            "bill_change:Q",
+            axis=alt.Axis(grid=True),
+            title="Bill change with respect to bill under status quo levies and social support (£)",
+            scale=alt.Scale(domain=[-850, 450]),
+        ),
+        y=alt.Y(
+            "Name:N",
+            axis=alt.Axis(grid=True, labelLimit=500),
+            sort=None,
+            title="Energy consumer archetype (Lowest (A) to highest (J) income)",
+        ),
+        size=alt.Size("ArchetypeSize:Q", title="No. of households"),
+        color=alt.Color(
+            "main_heating_fuel:N",
+            scale=alt.Scale(domain=list(cmap_2.keys()), range=list(cmap_2.values())),
+            title="Main heating fuel",
+        ),
+    )
+    # x=0 base line
+    rule = chart.mark_rule(strokeDash=[2, 2]).encode(x=alt.datum(0))
+    # Layer dots and line
+    chart = alt.layer(points, rule).properties(width=chart_width)
+    chart = chart.configure_axis(
+        labelColor="black", titleColor="black"
+    ).configure_legend(labelColor="black", titleColor="black")
+
+    return chart

--- a/asf_levies_model_app/utils/app_utils.py
+++ b/asf_levies_model_app/utils/app_utils.py
@@ -19,6 +19,7 @@ from asf_levies_model.summary import create_scenario_weights_dict
 
 
 def instantiate_levies(
+    fileobject_annex_4,
     supply_elec: float = 96_517_461.0,  # MWh
     supply_gas: float = 266_505_188.0,  # MWh
     customers_elec: int = 29_239_936,
@@ -48,36 +49,31 @@ def instantiate_levies(
     ncc_scaling_factor = supply_elec / ncc_eligible_supply
 
     # Instantiate status quo levies with Annex 4 data
-    @st.cache_data
-    def load_annex_4():
-        return data.download_annex_4(as_fileobject=True)
-
-    fileobject = load_annex_4()
     list_levies = [
         levies.RO.from_dataframe(
-            data.process_data_RO(fileobject), denominator=supply_elec
+            data.process_data_RO(fileobject_annex_4), denominator=supply_elec
         ),
         levies.AAHEDC.from_dataframe(
-            data.process_data_AAHEDC(fileobject), denominator=supply_elec
+            data.process_data_AAHEDC(fileobject_annex_4), denominator=supply_elec
         ),
         levies.GGL.from_dataframe(
-            data.process_data_GGL(fileobject), denominator=customers_gas
+            data.process_data_GGL(fileobject_annex_4), denominator=customers_gas
         ),
         levies.WHD.from_dataframe(
-            data.process_data_WHD(fileobject),
+            data.process_data_WHD(fileobject_annex_4),
             customers_gas=customers_gas,
             customers_elec=customers_elec,
         ),
-        levies.ECO.from_dataframe(data.process_data_ECO(fileobject)),
+        levies.ECO.from_dataframe(data.process_data_ECO(fileobject_annex_4)),
         levies.FIT.from_dataframe(
-            data.process_data_FIT(fileobject),
+            data.process_data_FIT(fileobject_annex_4),
             scaling_factor=fit_scaling_factor,
         ),
         levies.NCC.from_dataframe(
-            data.process_data_NCC(fileobject), scaling_factor=ncc_scaling_factor
+            data.process_data_NCC(fileobject_annex_4), scaling_factor=ncc_scaling_factor
         ),
     ]
-    fileobject.close()
+
     pc = levies.LevyCollection("Policy Costs", "pc", list_levies, denominator_values)
 
     # Rebalance baseline levies to reflect denominators
@@ -160,14 +156,9 @@ def get_approach_weights(levies: List, approach_name: str) -> Dict:
     return approach_weights[approach_name]
 
 
-def instantiate_tariffs(payment_method: str = "Other Payment") -> Dict:
-
-    # Load Annex 9
-    @st.cache_data
-    def load_annex_9():
-        return data.download_annex_9(as_fileobject=True)
-
-    fileobject_annex_9 = load_annex_9()
+def instantiate_tariffs(
+    fileobject_annex_9, payment_method: str = "Other Payment"
+) -> Dict:
 
     # Load tariff tables from Annex 9
     # Other payment
@@ -201,7 +192,6 @@ def instantiate_tariffs(payment_method: str = "Other Payment") -> Dict:
     gas_standard_credit_typical = data.process_tariff_gas_standard_credit_typical(
         fileobject_annex_9
     )
-    fileobject_annex_9.close()
 
     # Instantiate Tariff objects
     if payment_method == "Other Payment":
@@ -241,14 +231,11 @@ def update_gas_tariff_policy_cost(tariff, levies):
     return tariff
 
 
-def instantiate_archetype_consumers(gas_tariff, electricity_tariff):
-
-    # Load Ofgem energy consumer archetypes data
-    @st.cache_data
-    def load_archetypes():
-        return data.ofgem_archetypes_data()
-
-    ofgem_archetypes_df = load_archetypes()
+def instantiate_archetype_consumers(
+    ofgem_archetypes_df: pd.DataFrame,
+    gas_tariff: tariffs.Tariff,
+    electricity_tariff: tariffs.Tariff,
+):
 
     # Create list of Consumers (Average Ofgem archetypes only, n=24)
     consumers = [
@@ -272,15 +259,10 @@ def instantiate_archetype_consumers(gas_tariff, electricity_tariff):
 
 
 def instantiate_archetype_consumers_with_eligibility(
-    gas_tariff, electricity_tariff, eligibility_size_name
+    ofgem_archetypes_df: pd.DataFrame,
+    gas_tariff: tariffs.Tariff,
+    electricity_tariff: tariffs.Tariff,
 ):
-
-    # Load Ofgem energy consumer archetypes data
-    @st.cache_data
-    def load_archetypes():
-        return data.ofgem_archetypes_data()
-
-    ofgem_archetypes_df = load_archetypes()
 
     # Create list of eligible Consumers (Average Ofgem archetypes only, n=24)
     eligible_consumers = [
@@ -297,7 +279,6 @@ def instantiate_archetype_consumers_with_eligibility(
             / 1_000,
             gas_tariff=gas_tariff,
             electricity_tariff=electricity_tariff,
-            # size=ofgem_archetypes_df.loc[row, eligibility_size_name],
             scheme_eligible=True,
         )
         for row in range(1, 25)
@@ -318,8 +299,6 @@ def instantiate_archetype_consumers_with_eligibility(
             / 1_000,
             gas_tariff=gas_tariff,
             electricity_tariff=electricity_tariff,
-            # size=ofgem_archetypes_df.loc[row, "ArchetypeSize"]
-            # - ofgem_archetypes_df.loc[row, eligibility_size_name],
             scheme_eligible=True,
         )
         for row in range(1, 25)

--- a/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
+++ b/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
@@ -1,0 +1,310 @@
+import streamlit as st
+
+from asf_levies_model_app.utils.app_utils import (
+    instantiate_levies,
+    get_approach_weights,
+    instantiate_tariffs,
+    update_electricity_tariff_policy_cost,
+    update_gas_tariff_policy_cost,
+    instantiate_archetype_consumers,
+    calculate_unit_cost_ratio,
+    get_tidy_summary,
+    tidy_to_pivot_summary,
+    make_archetype_bill_change_chart,
+)
+
+from asf_levies_model.summary import (
+    set_common_denominators,
+    create_scenario_weights_dict,
+)
+import asf_levies_model.levies as levies
+import asf_levies_model.getters.load_data as data
+
+st.set_page_config(
+    page_title="Nesta Levies Rebalancing Model", page_icon="🏠", layout="wide"
+)
+
+st.title("Levies Rebalancing App💡")
+st.markdown(
+    "**from the [A Sustainable Future](https://www.nesta.org.uk/sustainable-future/) team at Nesta**"
+)
+
+# Instantiate baseline levies as LevyCollection (rebalanced to denominators)
+levies = instantiate_levies()
+
+# Create dictionary of denominators for each levy
+supply_elec = 96_517_461.0
+supply_gas = 266_505_188.0
+customers_elec = 29_239_936
+customers_gas = 24_605_467
+
+denominators = set_common_denominators(
+    levies,
+    supply_elec=supply_elec,
+    supply_gas=supply_gas,
+    customers_elec=customers_elec,
+    customers_gas=customers_gas,
+)
+
+# Show selectors for levy reform scenario in side bar
+with st.sidebar:
+    st.info(
+        "**Test a levy reform scenario** by adjusting the settings below. *Note: You can hide or adjust the width of this sidebar.*"
+    )
+
+    # User input to choose rebalancing approach
+    approach = st.radio(
+        "**Select a preset approach or create your own:**",
+        [
+            "Current",
+            "Rebalance all levies on electricity to gas",
+            "Remove all levies on electricity to taxation",
+            "Rebalance RO and FIT levies from electricity to gas",
+            "Remove RO and FIT levies from electricity to taxation",
+            "Create my own",
+        ],
+        index=0,
+    )
+
+    if approach == "Create my own":
+        rebalancing_weights = create_scenario_weights_dict(levies)
+
+        for levy in levies:
+
+            # Rebalance or move to tax
+            st.markdown("---")
+            mode = st.radio(
+                f"**{levy.name}**",
+                [
+                    "Rebalance between electricity and gas",
+                    "Remove off bills to general taxation",
+                ],
+                index=0,
+                key=f"{levy.short_name}_radio",
+            )
+
+            # Rebalancing weights: Fuel
+            if (
+                st.session_state[f"{levy.short_name}_radio"]
+                == "Rebalance between electricity and gas"
+            ):
+                rebalancing_weights[levy.short_name]["new_tax_weight"] = 0.0
+                rebalancing_weights[levy.short_name]["new_gas_weight"] = (
+                    st.slider(
+                        "Electricity (0) <-> Gas (100)",
+                        value=(rebalancing_weights[levy.short_name]["new_gas_weight"])
+                        * 100.0,
+                        min_value=0.0,
+                        max_value=100.0,
+                        step=1.0,
+                        key=f"{levy.short_name}_rebalancing_slider",
+                    )
+                    / 100.0
+                )
+                rebalancing_weights[levy.short_name]["new_electricity_weight"] = 1.0 - (
+                    rebalancing_weights[levy.short_name]["new_gas_weight"]
+                )
+
+            else:
+                rebalancing_weights[levy.short_name]["new_tax_weight"] = 0.0
+                rebalancing_weights[levy.short_name]["new_gas_weight"] = 1.0
+                rebalancing_weights[levy.short_name]["new_electricity_weight"] = 1.0
+
+            # Rebalancing weights: Unit costs vs standing charge
+
+            # Check for electricity levy rebalancing
+            if rebalancing_weights[levy.short_name]["new_electricity_weight"] != 0.0:
+                # Set initial mode based on weights
+                if (
+                    rebalancing_weights[levy.short_name]["new_variable_weight_elec"]
+                    == 1.0
+                ):
+                    elec_index = 0  # Variable weight mode
+                elif (
+                    rebalancing_weights[levy.short_name]["new_fixed_weight_elec"] != 0.0
+                ):
+                    elec_index = 1  # Fixed weight mode
+                else:
+                    # Default to either variable or fixed based on gas weight setting
+                    elec_index = (
+                        0
+                        if rebalancing_weights[levy.short_name][
+                            "new_variable_weight_gas"
+                        ]
+                        else 1
+                    )
+
+                # Display the radio button for levy mode on electricity
+                elec_mode = st.radio(
+                    "Mode of levy on electricity:",
+                    ["Unit cost", "Standing charge"],
+                    index=elec_index,
+                    key=f"{levy.short_name} elec mode",
+                )
+
+                # Update weights based on the selected mode
+                if elec_mode == "Unit cost":
+                    rebalancing_weights[levy.short_name][
+                        "new_variable_weight_elec"
+                    ] = 1.0
+                    rebalancing_weights[levy.short_name]["new_fixed_weight_elec"] = 0.0
+                else:
+                    rebalancing_weights[levy.short_name][
+                        "new_variable_weight_elec"
+                    ] = 0.0
+                    rebalancing_weights[levy.short_name]["new_fixed_weight_elec"] = 1.0
+
+            # Check for gas levy rebalancing
+            if rebalancing_weights[levy.short_name]["new_gas_weight"] != 0.0:
+                # Set initial mode based on weights
+                if (
+                    rebalancing_weights[levy.short_name]["new_variable_weight_gas"]
+                    == 1.0
+                ):
+                    gas_index = 0  # Variable weight mode
+                elif (
+                    rebalancing_weights[levy.short_name]["new_fixed_weight_gas"] != 0.0
+                ):
+                    gas_index = 1  # Fixed weight mode
+                else:
+                    # Default to either variable or fixed based on gas weight setting
+                    gas_index = (
+                        0
+                        if rebalancing_weights[levy.short_name][
+                            "new_variable_weight_elec"
+                        ]
+                        else 1
+                    )
+
+                # Display the radio button for levy mode on gas
+                gas_mode = st.radio(
+                    "Mode of levy on gas:",
+                    ["Unit cost", "Standing charge"],
+                    index=gas_index,
+                    key=f"{levy.short_name} gas mode",
+                )
+
+                # Update weights based on the selected mode
+                if gas_mode == "Unit cost":
+                    rebalancing_weights[levy.short_name][
+                        "new_variable_weight_gas"
+                    ] = 1.0
+                    rebalancing_weights[levy.short_name]["new_fixed_weight_gas"] = 0.0
+                else:
+                    rebalancing_weights[levy.short_name][
+                        "new_variable_weight_gas"
+                    ] = 0.0
+                    rebalancing_weights[levy.short_name]["new_fixed_weight_gas"] = 1.0
+
+    else:
+        rebalancing_weights = get_approach_weights(levies, approach)
+
+
+# Rebalance levies based on chosen approach
+rebalanced_levies = levies.rebalance_levies(
+    rebalancing_weights,
+    scenario_name="Rebalanced",
+)
+
+# Instantiate baseline tariffs
+baseline_tariffs = instantiate_tariffs(payment_method="Other Payment")
+baseline_electricity_tariff = update_electricity_tariff_policy_cost(
+    baseline_tariffs["electricity"], levies
+)
+baseline_gas_tariff = update_gas_tariff_policy_cost(baseline_tariffs["gas"], levies)
+
+# Instantiate rebalanced tariffs
+rebalanced_tariffs = instantiate_tariffs(payment_method="Other Payment")
+rebalanced_electricity_tariff = update_electricity_tariff_policy_cost(
+    rebalanced_tariffs["electricity"], rebalanced_levies
+)
+rebalanced_gas_tariff = update_gas_tariff_policy_cost(
+    rebalanced_tariffs["gas"], rebalanced_levies
+)
+
+# Create a list of Consumers (average Ofgem archetypes only, n=24) for baseline and rebalanced scenario
+baseline_consumers = instantiate_archetype_consumers(
+    baseline_gas_tariff, baseline_electricity_tariff
+)
+rebalanced_consumers = instantiate_archetype_consumers(
+    rebalanced_gas_tariff, rebalanced_electricity_tariff
+)
+
+# Result: Unit cost ratio
+baseline_ratio = calculate_unit_cost_ratio(
+    baseline_electricity_tariff, baseline_gas_tariff
+)
+rebalanced_ratio = calculate_unit_cost_ratio(
+    rebalanced_electricity_tariff, rebalanced_gas_tariff
+)
+
+# Result: Cost to taxpayers
+cost_to_tax = sum(
+    rebalancing_weights[levy.short_name]["new_tax_weight"] * levy.revenue
+    for levy in rebalanced_levies
+)
+
+col1, col2, col3 = st.columns(3)
+with col2:
+    st.warning(
+        f"**Electricity-to-gas ratio: {rebalanced_ratio:.2f}** *(Current: {baseline_ratio:.2f})*"
+    )
+with col3:
+    st.error(
+        f"**Additional cost to taxpayers: £{cost_to_tax/1_000_000_000:.2f} billion per year**"
+    )
+
+
+# Result: Distribution impacts dot chart
+baseline_summary_table = tidy_to_pivot_summary(
+    get_tidy_summary(baseline_consumers, "Baseline")
+)
+rebalanced_summary_table = tidy_to_pivot_summary(
+    get_tidy_summary(rebalanced_consumers, "Rebalanced")
+)
+# Add bill change column
+rebalanced_summary_table["bill_change"] = (
+    rebalanced_summary_table["combined_fuel_bill"]
+    - baseline_summary_table["combined_fuel_bill"]
+)
+
+# Add archetype sizes
+
+archetype_sizes = data.ofgem_archetypes_data()[
+    ["AnnualConsumptionProfile", "ArchetypeSize"]
+]
+archetype_sizes = archetype_sizes.rename(
+    columns={
+        "AnnualConsumptionProfile": "Name",
+    }
+)
+rebalanced_summary_table = rebalanced_summary_table.merge(
+    archetype_sizes, on="Name", how="left"
+)
+
+st.markdown(
+    f"<p style='color:black; font-size: 20px;'><b>Distributional impacts: Effect on energy bills</b></p>",
+    unsafe_allow_html=True,
+)
+
+chart = make_archetype_bill_change_chart(rebalanced_summary_table, chart_width=1000)
+st.altair_chart(chart)
+
+# Option to view results table
+if st.button("View distributional impacts results table"):
+    # Show link to distributional effects summary dataframe for download
+    @st.cache_data
+    def convert_df(df):
+        return df.to_csv(index=False).encode("utf-8")
+
+    csv = convert_df(rebalanced_summary_table)
+
+    st.download_button(
+        "Download table",
+        csv,
+        "rebalanced_scenario_distributional_effect.csv",
+        "text/csv",
+        key="download-csv",
+    )
+
+    st.write(rebalanced_summary_table)

--- a/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
+++ b/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
@@ -101,6 +101,7 @@ with st.sidebar:
     )
 
     if st.session_state.approach == "Create my own":
+        st.session_state.rebalancing_weights = create_scenario_weights_dict(levies)
 
         for levy in levies:
 
@@ -354,7 +355,16 @@ cost_to_tax = sum(
     for levy in rebalanced_levies
 )
 
+# Result: Energy price cap (i.e. typical household bill)
+baseline_price_cap = baseline_electricity_tariff.calculate_total_consumption(
+    2.7, vat=True
+) + baseline_gas_tariff.calculate_total_consumption(11.5, vat=True)
+rebalanced_price_cap = rebalanced_electricity_tariff.calculate_total_consumption(
+    2.7, vat=True
+) + rebalanced_gas_tariff.calculate_total_consumption(11.5, vat=True)
+
 col1, col2, col3 = st.columns(3)
+
 with col2:
     st.warning(
         f"**Electricity-to-gas ratio: {rebalanced_ratio:.2f}** *(Current: {baseline_ratio:.2f})*"
@@ -396,6 +406,11 @@ st.markdown(
     f"<p style='color:black; font-size: 20px;'><b>Distributional impacts: Effect on energy bills</b></p>",
     unsafe_allow_html=True,
 )
+col1, col2 = st.columns(2)
+with col2:
+    st.info(
+        f"**Typical household bill: £{rebalanced_price_cap:,.2f}** *(Current: £{baseline_price_cap:,.2f})*"
+    )
 
 chart = make_archetype_bill_change_chart(rebalanced_summary_table, chart_width=1000)
 st.altair_chart(chart)

--- a/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
+++ b/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
@@ -29,8 +29,17 @@ st.markdown(
     "**from the [A Sustainable Future](https://www.nesta.org.uk/sustainable-future/) team at Nesta**"
 )
 
+
 # Instantiate baseline levies as LevyCollection (rebalanced to denominators)
-levies = instantiate_levies()
+@st.cache_data
+def load_levies():
+    fileobject = data.download_annex_4(as_fileobject=True)
+    levies = instantiate_levies(fileobject)
+    fileobject.close()
+    return levies
+
+
+levies = load_levies()
 
 # Create dictionary of denominators for each levy
 supply_elec = 96_517_461.0
@@ -45,6 +54,23 @@ denominators = set_common_denominators(
     customers_elec=customers_elec,
     customers_gas=customers_gas,
 )
+
+# Initialise session state variables
+
+if "approach" not in st.session_state:
+    st.session_state.approach = "Current"
+
+if "rebalancing_weights" not in st.session_state:
+    st.session_state.rebalancing_weights = {}
+
+if "levy_modes" not in st.session_state:
+    st.session_state.levy_modes = {}
+
+if (
+    st.session_state.approach == "Create my own"
+    and not st.session_state.rebalancing_weights
+):
+    st.session_state.rebalancing_weights = create_scenario_weights_dict(levies)
 
 # Show selectors for levy reform scenario in side bar
 with st.sidebar:
@@ -63,36 +89,60 @@ with st.sidebar:
             "Remove RO and FIT levies from electricity to taxation",
             "Create my own",
         ],
-        index=0,
+        index=[
+            "Current",
+            "Rebalance all levies on electricity to gas",
+            "Remove all levies on electricity to taxation",
+            "Rebalance RO and FIT levies from electricity to gas",
+            "Remove RO and FIT levies from electricity to taxation",
+            "Create my own",
+        ].index(st.session_state.approach),
+        key="approach",
     )
 
-    if approach == "Create my own":
-        rebalancing_weights = create_scenario_weights_dict(levies)
+    if st.session_state.approach == "Create my own":
 
         for levy in levies:
 
-            # Rebalance or move to tax
             st.markdown("---")
-            mode = st.radio(
+
+            # Radio button for levy mode (rebalance or move to tax)
+            if levy.short_name not in st.session_state.levy_modes:
+                st.session_state.levy_modes[levy.short_name] = (
+                    "Rebalance between electricity and gas"
+                )
+
+            st.session_state.levy_modes[levy.short_name] = st.radio(
                 f"**{levy.name}**",
                 [
                     "Rebalance between electricity and gas",
                     "Remove off bills to general taxation",
                 ],
-                index=0,
+                index=[
+                    "Rebalance between electricity and gas",
+                    "Remove off bills to general taxation",
+                ].index(st.session_state.levy_modes[levy.short_name]),
                 key=f"{levy.short_name}_radio",
             )
 
             # Rebalancing weights: Fuel
             if (
-                st.session_state[f"{levy.short_name}_radio"]
+                st.session_state.levy_modes[levy.short_name]
                 == "Rebalance between electricity and gas"
             ):
-                rebalancing_weights[levy.short_name]["new_tax_weight"] = 0.0
-                rebalancing_weights[levy.short_name]["new_gas_weight"] = (
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_tax_weight"
+                ] = 0.0
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_gas_weight"
+                ] = (
                     st.slider(
                         "Electricity (0) <-> Gas (100)",
-                        value=(rebalancing_weights[levy.short_name]["new_gas_weight"])
+                        value=(
+                            st.session_state.rebalancing_weights[levy.short_name][
+                                "new_gas_weight"
+                            ]
+                        )
                         * 100.0,
                         min_value=0.0,
                         max_value=100.0,
@@ -101,35 +151,55 @@ with st.sidebar:
                     )
                     / 100.0
                 )
-                rebalancing_weights[levy.short_name]["new_electricity_weight"] = 1.0 - (
-                    rebalancing_weights[levy.short_name]["new_gas_weight"]
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_electricity_weight"
+                ] = 1.0 - (
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_gas_weight"
+                    ]
                 )
 
             # Rebalancing weights: To general taxation
             else:
-                rebalancing_weights[levy.short_name]["new_tax_weight"] = 1.0
-                rebalancing_weights[levy.short_name]["new_gas_weight"] = 0.0
-                rebalancing_weights[levy.short_name]["new_electricity_weight"] = 0.0
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_tax_weight"
+                ] = 1.0
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_gas_weight"
+                ] = 0.0
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_electricity_weight"
+                ] = 0.0
 
             # Rebalancing weights: Unit costs vs standing charge
 
             # Check for electricity levy rebalancing
-            if rebalancing_weights[levy.short_name]["new_electricity_weight"] != 0.0:
+            if (
+                st.session_state.rebalancing_weights[levy.short_name][
+                    "new_electricity_weight"
+                ]
+                != 0.0
+            ):
                 # Set initial mode based on weights
                 if (
-                    rebalancing_weights[levy.short_name]["new_variable_weight_elec"]
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_variable_weight_elec"
+                    ]
                     == 1.0
                 ):
                     elec_index = 0  # Variable weight mode
                 elif (
-                    rebalancing_weights[levy.short_name]["new_fixed_weight_elec"] != 0.0
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_fixed_weight_elec"
+                    ]
+                    != 0.0
                 ):
                     elec_index = 1  # Fixed weight mode
                 else:
                     # Default to either variable or fixed based on gas weight setting
                     elec_index = (
                         0
-                        if rebalancing_weights[levy.short_name][
+                        if st.session_state.rebalancing_weights[levy.short_name][
                             "new_variable_weight_gas"
                         ]
                         else 1
@@ -140,38 +210,50 @@ with st.sidebar:
                     "Mode of levy on electricity:",
                     ["Unit cost", "Standing charge"],
                     index=elec_index,
-                    key=f"{levy.short_name} elec mode",
+                    key=f"{levy.short_name}_elec_mode",
                 )
 
                 # Update weights based on the selected mode
                 if elec_mode == "Unit cost":
-                    rebalancing_weights[levy.short_name][
+                    st.session_state.rebalancing_weights[levy.short_name][
                         "new_variable_weight_elec"
                     ] = 1.0
-                    rebalancing_weights[levy.short_name]["new_fixed_weight_elec"] = 0.0
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_fixed_weight_elec"
+                    ] = 0.0
                 else:
-                    rebalancing_weights[levy.short_name][
+                    st.session_state.rebalancing_weights[levy.short_name][
                         "new_variable_weight_elec"
                     ] = 0.0
-                    rebalancing_weights[levy.short_name]["new_fixed_weight_elec"] = 1.0
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_fixed_weight_elec"
+                    ] = 1.0
 
             # Check for gas levy rebalancing
-            if rebalancing_weights[levy.short_name]["new_gas_weight"] != 0.0:
+            if (
+                st.session_state.rebalancing_weights[levy.short_name]["new_gas_weight"]
+                != 0.0
+            ):
                 # Set initial mode based on weights
                 if (
-                    rebalancing_weights[levy.short_name]["new_variable_weight_gas"]
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_variable_weight_gas"
+                    ]
                     == 1.0
                 ):
                     gas_index = 0  # Variable weight mode
                 elif (
-                    rebalancing_weights[levy.short_name]["new_fixed_weight_gas"] != 0.0
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_fixed_weight_gas"
+                    ]
+                    != 0.0
                 ):
                     gas_index = 1  # Fixed weight mode
                 else:
                     # Default to either variable or fixed based on gas weight setting
                     gas_index = (
                         0
-                        if rebalancing_weights[levy.short_name][
+                        if st.session_state.rebalancing_weights[levy.short_name][
                             "new_variable_weight_elec"
                         ]
                         else 1
@@ -182,40 +264,58 @@ with st.sidebar:
                     "Mode of levy on gas:",
                     ["Unit cost", "Standing charge"],
                     index=gas_index,
-                    key=f"{levy.short_name} gas mode",
+                    key=f"{levy.short_name}_gas_mode",
                 )
 
                 # Update weights based on the selected mode
                 if gas_mode == "Unit cost":
-                    rebalancing_weights[levy.short_name][
+                    st.session_state.rebalancing_weights[levy.short_name][
                         "new_variable_weight_gas"
                     ] = 1.0
-                    rebalancing_weights[levy.short_name]["new_fixed_weight_gas"] = 0.0
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_fixed_weight_gas"
+                    ] = 0.0
                 else:
-                    rebalancing_weights[levy.short_name][
+                    st.session_state.rebalancing_weights[levy.short_name][
                         "new_variable_weight_gas"
                     ] = 0.0
-                    rebalancing_weights[levy.short_name]["new_fixed_weight_gas"] = 1.0
+                    st.session_state.rebalancing_weights[levy.short_name][
+                        "new_fixed_weight_gas"
+                    ] = 1.0
 
     else:
-        rebalancing_weights = get_approach_weights(levies, approach)
+        st.session_state.rebalancing_weights = get_approach_weights(
+            levies, st.session_state.approach
+        )
 
 
 # Rebalance levies based on chosen approach
 rebalanced_levies = levies.rebalance_levies(
-    rebalancing_weights,
+    st.session_state.rebalancing_weights,
     scenario_name="Rebalanced",
 )
 
-# Instantiate baseline tariffs
-baseline_tariffs = instantiate_tariffs(payment_method="Other Payment")
+
+# Instantiate baseline and rebalanced tariffs
+@st.cache_data
+def load_tariffs():
+    fileobject = data.download_annex_9(as_fileobject=True)
+    baseline_tariffs = instantiate_tariffs(
+        fileobject_annex_9=fileobject, payment_method="Other Payment"
+    )
+    rebalanced_tariffs = instantiate_tariffs(
+        fileobject_annex_9=fileobject, payment_method="Other Payment"
+    )
+    fileobject.close()
+    return baseline_tariffs, rebalanced_tariffs
+
+
+baseline_tariffs, rebalanced_tariffs = load_tariffs()
+
 baseline_electricity_tariff = update_electricity_tariff_policy_cost(
     baseline_tariffs["electricity"], levies
 )
 baseline_gas_tariff = update_gas_tariff_policy_cost(baseline_tariffs["gas"], levies)
-
-# Instantiate rebalanced tariffs
-rebalanced_tariffs = instantiate_tariffs(payment_method="Other Payment")
 rebalanced_electricity_tariff = update_electricity_tariff_policy_cost(
     rebalanced_tariffs["electricity"], rebalanced_levies
 )
@@ -223,12 +323,20 @@ rebalanced_gas_tariff = update_gas_tariff_policy_cost(
     rebalanced_tariffs["gas"], rebalanced_levies
 )
 
+
 # Create a list of Consumers (average Ofgem archetypes only, n=24) for baseline and rebalanced scenario
+@st.cache_data
+def load_archetypes():
+    return data.ofgem_archetypes_data()
+
+
+ofgem_archetypes_df = load_archetypes()
+
 baseline_consumers = instantiate_archetype_consumers(
-    baseline_gas_tariff, baseline_electricity_tariff
+    ofgem_archetypes_df, baseline_gas_tariff, baseline_electricity_tariff
 )
 rebalanced_consumers = instantiate_archetype_consumers(
-    rebalanced_gas_tariff, rebalanced_electricity_tariff
+    ofgem_archetypes_df, rebalanced_gas_tariff, rebalanced_electricity_tariff
 )
 
 # Result: Unit cost ratio
@@ -241,7 +349,8 @@ rebalanced_ratio = calculate_unit_cost_ratio(
 
 # Result: Cost to taxpayers
 cost_to_tax = sum(
-    rebalancing_weights[levy.short_name]["new_tax_weight"] * levy.revenue
+    st.session_state.rebalancing_weights[levy.short_name]["new_tax_weight"]
+    * levy.revenue
     for levy in rebalanced_levies
 )
 

--- a/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
+++ b/asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py
@@ -105,10 +105,11 @@ with st.sidebar:
                     rebalancing_weights[levy.short_name]["new_gas_weight"]
                 )
 
+            # Rebalancing weights: To general taxation
             else:
-                rebalancing_weights[levy.short_name]["new_tax_weight"] = 0.0
-                rebalancing_weights[levy.short_name]["new_gas_weight"] = 1.0
-                rebalancing_weights[levy.short_name]["new_electricity_weight"] = 1.0
+                rebalancing_weights[levy.short_name]["new_tax_weight"] = 1.0
+                rebalancing_weights[levy.short_name]["new_gas_weight"] = 0.0
+                rebalancing_weights[levy.short_name]["new_electricity_weight"] = 0.0
 
             # Rebalancing weights: Unit costs vs standing charge
 


### PR DESCRIPTION
---

# Description

This code introduces a new version of the app with two pages:
1. "Run a rebalancing scenario" in `asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py`. This is the landing page.
2. "How-to" in `asf_levies_model_app/pages/1_❓_How-to.py`. This is an additional page that can be navigated to via the sidebar.

The rebalancing page is similar to the previous version but cleaned up to
- only show the sliders for individual levy configuration if the "Create your own" approach is selected (I think doing it this way has avoided the need to explicitly manage the session state variables)
- only allow unit cost or standing charge mode for a given levy, not a mixture of both
- show all results on the main page (price ratio, public spend total and archetype bill changes) in a more condensed format to save users from scrolling up and down

In order to run the code in this PR you need to install the `asf_levies_model` package from github into your conda environment. Other required packages are` streamlit`, `altair` and `pandas`.

Please can you:

1. Review the code in `asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py` and `asf_levies_model_app/utils/app_utils.py` in general, paying particular attention to the handling of rebalancing weights under the "Create your own" condition. (NB I wrote the functions in `app_utils.py` before our most recent model developments so some of the functions may be superseded by new methods. I can refactor this at a later date once the blog piece is finalised.)

2. User test the app by running this command line: `streamlit run asf_levies_model_app/🎯_Run_a_rebalancing_scenario.py`. Please try all combinations and see if there is any sequence of selections that break the app. 



# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
